### PR TITLE
Compiler issue fix (MacOS Catalina) stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -121,3 +121,9 @@ docker:
   enable: false
 
 pvp-bounds: lower
+
+
+# Uncomment below to correct compiler issue on Mac OS 10.15.15 (Catalina). 
+#apply-ghc-options: everything
+#ghc-options:
+#  $everything: -optc -Wno-unused-command-line-argument


### PR DESCRIPTION
Fixes compiler issue error for Mac OS Catalina 10.15.15:
"clang: warning: argument unused during compilation: '-nopie' [-Wunused-command-line-argument]"

Proposed fix appended at lines 126-129.