### PR TITLE
fix(matrixValidity): print rows before columns consistently with error message

### DIFF
--- a/src/TooManyCells/Matrix/Utility.hs
+++ b/src/TooManyCells/Matrix/Utility.hs
@@ -306,9 +306,9 @@ matrixValidity mat
                            <> ","
                            <> show numCells
                            <> ") with matrix (rows, columns) ("
-                           <> show cols
-                           <> ","
                            <> show rows
+                           <> ","
+                           <> show cols
                            <> "), will probably result in error."
   | otherwise = Nothing
   where


### PR DESCRIPTION
The message has rows,cols, but the code seems to be printing cols,rows.