### PR TITLE
Revert "fix(matrixValidity): print rows before columns consistently with error message"

### DIFF
--- a/src/TooManyCells/Matrix/Utility.hs
+++ b/src/TooManyCells/Matrix/Utility.hs
@@ -306,9 +306,9 @@ matrixValidity mat
                            <> ","
                            <> show numCells
                            <> ") with matrix (rows, columns) ("
-                           <> show rows
-                           <> ","
                            <> show cols
+                           <> ","
+                           <> show rows
                            <> "), will probably result in error."
   | otherwise = Nothing
   where


### PR DESCRIPTION
Reverts GregorySchwartz/too-many-cells#53

Reasoning is that cells refers to Cell Ranger columns, but we store as rows in the program.